### PR TITLE
GitHub Actionsのworkflowを更新

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,16 +16,14 @@ jobs:
     env:
       FEATURES: avcodec,avdevice,avfilter,avformat,postproc,swresample,swscale
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
           apt update
           apt install -y --no-install-recommends clang curl pkg-config
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          override: true
           components: rustfmt, clippy
       - name: Build
         run: |
@@ -51,7 +49,7 @@ jobs:
       FEATURES: avcodec,avdevice,avfilter,avformat,swresample,swscale #,postproc
       FFMPEG_DIR: /home/runner/work/rust-ffmpeg-sys/rust-ffmpeg-sys/ffmpeg-7.1-linux-clang-default
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
           sudo apt update
@@ -60,10 +58,8 @@ jobs:
           tar -xf ffmpeg.tar.xz
           pwd
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          override: true
           components: rustfmt, clippy
       - name: Build
         run: |


### PR DESCRIPTION
- `actions-rs/toolchain`を使っているところでActionsの実行が落ちているっぽいので`dtolnay/rust-toolchain`に変更
- `actions/checkout`のバージョンが古くて警告が出ていたので更新